### PR TITLE
Supports default ConfigMap params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ARCH ?= amd64
 VERSION := $(shell git describe --always --dirty)
 #
 # This version-strategy uses a manual value to set the version string
-#VERSION := 1.2.3
+# VERSION := 1.0.0
 
 ###
 ### These variables should not need tweaking.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Usage of cluster-proportional-autoscaler:
 ```
       --alsologtostderr[=false]: log to standard error as well as files
       --configmap="": ConfigMap containing our scaling parameters.
+      --default-params="": Default parameters(JSON format) for auto-scaling. Will create/re-create a ConfigMap with this default params if not present.
       --log-backtrace-at=:0: when logging hits line file:N, emit a stack trace
       --log-dir="": If non-empty, write log files in this directory
       --logtostderr[=false]: log to standard error instead of files
@@ -53,7 +54,7 @@ Parameters in ConfigMap must be JSON and use `linear` as key. The sub-keys as be
 ```
 data:
   linear: |-
-    { 
+    {
       "coresPerReplica": 2,
       "nodesPerReplica": 1,
       "min": 1,
@@ -82,7 +83,7 @@ Parameters in ConfigMap must be JSON and use `ladder` as key. The sub-keys as be
 ```
 data:
   ladder: |-
-    { 
+    {
       "coresToReplicas":
       [
         [ 1, 1 ],
@@ -113,14 +114,16 @@ Either one of the `coresToReplicas` or `nodesToReplicas` could be omitted.
 
 The lowest number of replicas is set to 1.
 
-## Example deployment file
+## Example deployment files
 
-This [autoscaler-linear-example.yaml](autoscaler-linear-example.yaml) and [autoscaler-ladder-example.yaml](autoscaler-ladder-example.yaml) are two example yaml files where an autoscaler pod watch and resizes the Deployment replicas of the nginx server.
-They are using different control modes. Use below command to create / delete one of the example:
+There are several example yaml files in the example folder, each of them will deploy an autoscaler pod watch and resizes the Deployment replicas of the nginx server.
+They are using different control modes. The autoscaler accepts default parameters passed by `--default-params` flag. Default ConfigMap will be created/re-created if default params present. Also see the example yaml files for example.
+
+Use below command to create / delete one of the example:
 ```
-kubectl create -f autoscaler-linear-example.yaml
+kubectl create -f linear.yaml
 ...
-kubectl delete -f autoscaler-linear-example.yaml
+kubectl delete -f linear.yaml
 ```
 
 # Comparisons to the Horizontal Pod Autoscaler feature

--- a/cmd/cluster-proportional-autoscaler/options/options_test.go
+++ b/cmd/cluster-proportional-autoscaler/options/options_test.go
@@ -60,7 +60,7 @@ func TestIsTargetFormatValid(t *testing.T) {
 		tc.target = strings.ToLower(tc.target)
 		res := isTargetFormatValid(tc.target)
 		if res != tc.expResult {
-			t.Errorf("target format verification for [%v] failed. Expected %v, Got %v", tc.target, tc.expResult, res)
+			t.Errorf("Target format verification for [%v] failed. Expected %v, Got %v", tc.target, tc.expResult, res)
 		}
 	}
 }

--- a/examples/ladder-no-configmap.yaml
+++ b/examples/ladder-no-configmap.yaml
@@ -1,0 +1,63 @@
+# Copyright 2016 The Kubernetes Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-autoscale-example
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: nginx-autoscale-example
+    spec:
+      containers:
+      - name: nginx-autoscale-example
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-autoscaler
+  namespace: default
+  labels:
+    app: autoscaler
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: autoscaler
+    spec:
+      containers:
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
+          name: autoscaler
+          env:
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /cluster-proportional-autoscaler
+            - --namespace=default
+            - --configmap=nginx-autoscaler
+            - --mode=ladder
+            - --target=deployment/nginx-autoscale-example
+            - --default-params={"ladder":{"coresToReplicas":[[1, 1],[2, 2],[3, 4],[512, 5]],"nodesToReplicas":[[ 1,1 ],[ 2,2 ]]}}
+            - --logtostderr=true
+            - --v=2

--- a/examples/ladder.yaml
+++ b/examples/ladder.yaml
@@ -1,0 +1,94 @@
+# Copyright 2016 The Kubernetes Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-autoscaler
+  namespace: default
+data:
+  ladder: |-
+    { 
+      "coresToReplicas":
+      [
+        [ 1,1 ],
+        [ 3,3 ],
+        [ 512,5 ],
+        [ 1024,7 ],
+        [ 2048,10 ],
+        [ 4096,15 ],
+        [ 8192,20 ],
+        [ 12288,30 ],
+        [ 16384,40 ],
+        [ 20480,50 ],
+        [ 24576,60 ],
+        [ 28672,70 ],
+        [ 32768,80 ],
+        [ 65535,100 ]
+      ],
+      "nodesToReplicas":
+      [
+        [ 1,1 ],
+        [ 2,2 ]
+      ]
+    }
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-autoscale-example
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: nginx-autoscale-example
+    spec:
+      containers:
+      - name: nginx-autoscale-example
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-autoscaler
+  namespace: default
+  labels:
+    app: autoscaler
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: autoscaler
+    spec:
+      containers:
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
+          name: autoscaler
+          env:
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /cluster-proportional-autoscaler
+            - --namespace=default
+            - --configmap=nginx-autoscaler
+            - --mode=ladder
+            - --target=deployment/nginx-autoscale-example
+            - --logtostderr=true
+            - --v=2

--- a/examples/linear-no-configmap.yaml
+++ b/examples/linear-no-configmap.yaml
@@ -12,38 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: nginx-cluster-proportional-autoscaler-params
-  namespace: default
-data:
-  ladder: |-
-    { 
-      "coresToReplicas":
-      [
-        [ 1,1 ],
-        [ 3,3 ],
-        [ 512,5 ],
-        [ 1024,7 ],
-        [ 2048,10 ],
-        [ 4096,15 ],
-        [ 8192,20 ],
-        [ 12288,30 ],
-        [ 16384,40 ],
-        [ 20480,50 ],
-        [ 24576,60 ],
-        [ 28672,70 ],
-        [ 32768,80 ],
-        [ 65535,100 ]
-      ],
-      "nodesToReplicas":
-      [
-        [ 1,1 ],
-        [ 2,2 ]
-      ]
-    }
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -65,7 +33,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: cluster-proportional-autoscaler
+  name: nginx-autoscaler
   namespace: default
   labels:
     app: autoscaler
@@ -77,7 +45,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:0.8.0
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
           name: autoscaler
           env:
             - name: MY_POD_NAMESPACE
@@ -87,8 +55,9 @@ spec:
           command:
             - /cluster-proportional-autoscaler
             - --namespace=default
-            - --configmap=nginx-cluster-proportional-autoscaler-params
-            - --mode=ladder
+            - --configmap=nginx-autoscaler
+            - --mode=linear
             - --target=deployment/nginx-autoscale-example
+            - --default-params={"linear":{"coresPerReplica":2,"nodesPerReplica":1,"min":1}}
             - --logtostderr=true
-            - --v=4
+            - --v=2

--- a/examples/linear.yaml
+++ b/examples/linear.yaml
@@ -15,15 +15,14 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: nginx-cluster-proportional-autoscaler-params
+  name: nginx-autoscaler
   namespace: default
 data:
   linear: |-
     { 
       "coresPerReplica": 2,
       "nodesPerReplica": 1,
-      "min": 1,
-      "max": 100
+      "min": 1
     }
 ---
 apiVersion: extensions/v1beta1
@@ -47,7 +46,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: cluster-proportional-autoscaler
+  name: nginx-autoscaler
   namespace: default
   labels:
     app: autoscaler
@@ -59,7 +58,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:0.8.0
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
           name: autoscaler
           env:
             - name: MY_POD_NAMESPACE
@@ -69,8 +68,8 @@ spec:
           command:
             - /cluster-proportional-autoscaler
             - --namespace=default
-            - --configmap=nginx-cluster-proportional-autoscaler-params
+            - --configmap=nginx-autoscaler
             - --mode=linear
             - --target=deployment/nginx-autoscale-example
             - --logtostderr=true
-            - --v=4
+            - --v=2

--- a/pkg/autoscaler/controller/controller.go
+++ b/pkg/autoscaler/controller/controller.go
@@ -20,8 +20,11 @@ import (
 	"github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/k8sclient"
 )
 
-type Interface interface {
+type Controller interface {
+	// GetExpectedReplicas returns the expected replicas based on cluster status
 	GetExpectedReplicas(k8sclient.ClusterStatus) (int32, error)
-	SyncConfig(k8sclient.ConfigMap) error
+	// SyncConfig synces the ConfigMap with controller
+	SyncConfig(*k8sclient.ConfigMap) error
+	// GetParamsVersion returns the latest parameters version from controller
 	GetParamsVersion() string
 }

--- a/pkg/autoscaler/controller/laddercontroller/ladder_controller.go
+++ b/pkg/autoscaler/controller/laddercontroller/ladder_controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/glog"
 )
 
-var _ = controller.Interface(&LadderController{})
+var _ = controller.Controller(&LadderController{})
 
 const (
 	ControllerType = "ladder"
@@ -38,7 +38,7 @@ type LadderController struct {
 	version string
 }
 
-func NewLadderController() controller.Interface {
+func NewLadderController() controller.Controller {
 	return &LadderController{}
 }
 
@@ -63,13 +63,13 @@ type ladderParams struct {
 	NodesToReplicas paramEntries `json:"nodesToReplicas"`
 }
 
-func (c *LadderController) SyncConfig(configMap k8sclient.ConfigMap) error {
+func (c *LadderController) SyncConfig(configMap *k8sclient.ConfigMap) error {
 	glog.V(0).Infof("Detected ConfigMap version change (old: %s new: %s) - rebuilding lookup entries\n", c.version, configMap.Version)
+	glog.V(2).Infof("Params from apiserver: \n%v", configMap.Data[ControllerType])
 	params, err := parseParams([]byte(configMap.Data[ControllerType]))
 	if err != nil {
 		return fmt.Errorf("error parsing ladder params: %s", err)
 	}
-	glog.V(4).Infof("Parsed new params: %v\n", params)
 	sort.Sort(params.CoresToReplicas)
 	sort.Sort(params.NodesToReplicas)
 	c.params = params

--- a/pkg/autoscaler/controller/laddercontroller/ladder_controller_test.go
+++ b/pkg/autoscaler/controller/laddercontroller/ladder_controller_test.go
@@ -25,24 +25,24 @@ import (
 
 func verifyParams(t *testing.T, scalerParams, expScalerParams *ladderParams) {
 	if len(expScalerParams.CoresToReplicas) != len(scalerParams.CoresToReplicas) {
-		t.Errorf("scaler Params length mismatch Expected: %d, Got %d", len(expScalerParams.CoresToReplicas), len(scalerParams.CoresToReplicas))
+		t.Errorf("Scaler Params length mismatch Expected: %d, Got %d", len(expScalerParams.CoresToReplicas), len(scalerParams.CoresToReplicas))
 		return
 	}
 	for n, expected := range expScalerParams.CoresToReplicas {
 		parsed := scalerParams.CoresToReplicas[n]
 		if expected[0] != parsed[0] || expected[1] != parsed[1] {
-			t.Errorf("scaler parser error - Expected value %v MISMATCHED: Got %v", expected, parsed)
+			t.Errorf("Scaler parser error - Expected value %v MISMATCHED: Got %v", expected, parsed)
 		}
 	}
 
 	if len(expScalerParams.NodesToReplicas) != len(scalerParams.NodesToReplicas) {
-		t.Errorf("scaler Params length mismatch Expected: %d, Got %d", len(expScalerParams.NodesToReplicas), len(scalerParams.NodesToReplicas))
+		t.Errorf("Scaler Params length mismatch Expected: %d, Got %d", len(expScalerParams.NodesToReplicas), len(scalerParams.NodesToReplicas))
 		return
 	}
 	for n, expected := range expScalerParams.NodesToReplicas {
 		parsed := scalerParams.NodesToReplicas[n]
 		if expected[0] != parsed[0] || expected[1] != parsed[1] {
-			t.Errorf("scaler parser error - Expected value %v MISMATCHED: Got %v", expected, parsed)
+			t.Errorf("Scaler parser error - Expected value %v MISMATCHED: Got %v", expected, parsed)
 		}
 	}
 }
@@ -126,14 +126,14 @@ func TestControllerParser(t *testing.T) {
 		params, err := parseParams([]byte(tc.jsonData))
 		if tc.expError {
 			if err == nil {
-				t.Errorf("unexpected parsing success. Expected failure")
+				t.Errorf("Unexpected parsing success. Expected failure")
 				spew.Dump(tc)
 				spew.Dump(params)
 			}
 			continue
 		}
 		if err != nil && !tc.expError {
-			t.Errorf("unexpected parse failure")
+			t.Errorf("Unexpected parse failure: %v", err)
 			spew.Dump(tc)
 			continue
 		}
@@ -245,29 +245,28 @@ func TestControllerScaler(t *testing.T) {
 	}
 
 	testCases := []struct {
-		entries      []paramEntry
 		numResources int
 		expReplicas  int
 	}{
-		{testEntries, 0, 1},
-		{testEntries, 1, 1},
-		{testEntries, 2, 2},
-		{testEntries, 3, 3},
-		{testEntries, 4, 4},
-		{testEntries, 6, 4},
-		{testEntries, 6, 4},
-		{testEntries, 10, 10},
-		{testEntries, 11, 10},
-		{testEntries, 19, 10},
-		{testEntries, 20, 20},
-		{testEntries, 21, 20},
-		{testEntries, 21, 20},
-		{testEntries, 40, 20},
+		{0, 1},
+		{1, 1},
+		{2, 2},
+		{3, 3},
+		{4, 4},
+		{6, 4},
+		{6, 4},
+		{10, 10},
+		{11, 10},
+		{19, 10},
+		{20, 20},
+		{21, 20},
+		{21, 20},
+		{40, 20},
 	}
 
 	for _, tc := range testCases {
-		if replicas := getExpectedReplicasFromEntries(tc.numResources, tc.entries); tc.expReplicas != replicas {
-			t.Errorf("scaler Lookup failed Expected %d, Got %d", tc.expReplicas, replicas)
+		if replicas := getExpectedReplicasFromEntries(tc.numResources, testEntries); tc.expReplicas != replicas {
+			t.Errorf("Scaler Lookup failed Expected %d, Got %d", tc.expReplicas, replicas)
 		}
 	}
 }

--- a/pkg/autoscaler/controller/linearcontroller/linear_controller.go
+++ b/pkg/autoscaler/controller/linearcontroller/linear_controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/glog"
 )
 
-var _ = controller.Interface(&LinearController{})
+var _ = controller.Controller(&LinearController{})
 
 const (
 	ControllerType = "linear"
@@ -38,7 +38,7 @@ type LinearController struct {
 	version string
 }
 
-func NewLinearController() controller.Interface {
+func NewLinearController() controller.Controller {
 	return &LinearController{}
 }
 
@@ -49,13 +49,13 @@ type linearParams struct {
 	Max             int `json:"max"`
 }
 
-func (c *LinearController) SyncConfig(configMap k8sclient.ConfigMap) error {
+func (c *LinearController) SyncConfig(configMap *k8sclient.ConfigMap) error {
 	glog.V(0).Infof("ConfigMap version change (old: %s new: %s) - rebuilding params\n", c.version, configMap.Version)
+	glog.V(2).Infof("Params from apiserver: \n%v", configMap.Data[ControllerType])
 	params, err := parseParams([]byte(configMap.Data[ControllerType]))
 	if err != nil {
 		return fmt.Errorf("error parsing linear params: %s", err)
 	}
-	glog.V(4).Infof("Parsed new params: %v\n", params)
 	c.params = params
 	c.version = configMap.Version
 	return nil

--- a/pkg/autoscaler/controller/linearcontroller/linear_controller_test.go
+++ b/pkg/autoscaler/controller/linearcontroller/linear_controller_test.go
@@ -27,7 +27,7 @@ func verifyParams(t *testing.T, scalerParams, expScalerParams *linearParams) {
 		scalerParams.NodesPerReplica != expScalerParams.NodesPerReplica ||
 		scalerParams.Min != expScalerParams.Min ||
 		scalerParams.Max != expScalerParams.Max {
-		t.Errorf("parser error - Expected params %v MISMATCHED: Got %v", expScalerParams, scalerParams)
+		t.Errorf("Parser error - Expected params %v MISMATCHED: Got %v", expScalerParams, scalerParams)
 	}
 }
 
@@ -38,7 +38,7 @@ func TestControllerParser(t *testing.T) {
 		expParams *linearParams
 	}{
 		{
-			`{ 
+			`{
 		      "coresPerReplica": 2,
 		      "nodesPerReplica": 1,
 		      "min": 1,
@@ -90,14 +90,14 @@ func TestControllerParser(t *testing.T) {
 		params, err := parseParams([]byte(tc.jsonData))
 		if tc.expError {
 			if err == nil {
-				t.Errorf("unexpected parsing success. Expected failure")
+				t.Errorf("Unexpected parsing success. Expected failure")
 				spew.Dump(tc)
 				spew.Dump(params)
 			}
 			continue
 		}
 		if err != nil && !tc.expError {
-			t.Errorf("unexpected parse failure")
+			t.Errorf("Unexpected parse failure: %v", err)
 			spew.Dump(tc)
 			continue
 		}
@@ -135,7 +135,7 @@ func TestScaleFromSingleParam(t *testing.T) {
 
 	for _, tc := range testCases {
 		if replicas := testController.getExpectedReplicasFromParam(tc.numResources, testController.params.CoresPerReplica); tc.expReplicas != replicas {
-			t.Errorf("scaler Lookup failed Expected %d, Got %d", tc.expReplicas, replicas)
+			t.Errorf("Scaler Lookup failed Expected %d, Got %d", tc.expReplicas, replicas)
 		}
 	}
 }
@@ -172,7 +172,7 @@ func TestScaleFromMultipleParams(t *testing.T) {
 
 	for _, tc := range testCases {
 		if replicas := testController.getExpectedReplicasFromParams(tc.numNodes, tc.numCores); tc.expReplicas != replicas {
-			t.Errorf("scaler Lookup failed Expected %d, Got %d", tc.expReplicas, replicas)
+			t.Errorf("Scaler Lookup failed Expected %d, Got %d", tc.expReplicas, replicas)
 		}
 	}
 }

--- a/pkg/autoscaler/k8sclient/k8sclient_test.go
+++ b/pkg/autoscaler/k8sclient/k8sclient_test.go
@@ -56,14 +56,14 @@ func TestGetScaleTarget(t *testing.T) {
 	for _, tc := range testCases {
 		res, err := getScaleTarget(tc.target, "default")
 		if err != nil && !tc.expError {
-			t.Errorf("expect no error, got error for target: %v", tc.target)
+			t.Errorf("Expect no error, got error for target: %v", tc.target)
 			continue
 		} else if err == nil && tc.expError {
-			t.Errorf("expect error, got no error for target: %v", tc.target)
+			t.Errorf("Expect error, got no error for target: %v", tc.target)
 			continue
 		}
 		if res.kind != tc.expKind || res.name != tc.expName {
-			t.Errorf("expect kind: %v, name: %v\ngot kind: %v, name: %v", tc.expKind, tc.expName, res.kind, res.name)
+			t.Errorf("Expect kind: %v, name: %v\ngot kind: %v, name: %v", tc.expKind, tc.expName, res.kind, res.name)
 		}
 	}
 }

--- a/pkg/autoscaler/k8sclient/mock_k8sclient.go
+++ b/pkg/autoscaler/k8sclient/mock_k8sclient.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 )
 
-var _ = Interface(&MockK8sClient{})
+var _ = K8sClient(&MockK8sClient{})
 
 // MockK8sClient implements K8sClientInterface
 type MockK8sClient struct {
@@ -30,11 +30,19 @@ type MockK8sClient struct {
 	NumOfReplicas int
 }
 
-func (k *MockK8sClient) FetchConfigMap(namespace, configmap string) (ConfigMap, error) {
+func (k *MockK8sClient) FetchConfigMap(namespace, configmap string) (*ConfigMap, error) {
 	if k.ConfigMap.Version == "" {
-		return ConfigMap{}, fmt.Errorf("config map not exist")
+		return nil, fmt.Errorf("config map not exist")
 	}
-	return k.ConfigMap, nil
+	return &(k.ConfigMap), nil
+}
+
+func (k *MockK8sClient) CreateConfigMap(namespace, configmap string, params map[string]string) (*ConfigMap, error) {
+	return nil, nil
+}
+
+func (k *MockK8sClient) UpdateConfigMap(namespace, configmap string, params map[string]string) (*ConfigMap, error) {
+	return nil, nil
 }
 
 func (k *MockK8sClient) GetClusterStatus() (ClusterStatus, error) {


### PR DESCRIPTION
Fix #7.

Added `--default-params` flag for passing in the default params(in JSON format) of ConfigMap. If corresponding ConfigMap not exist / deleted on apiserver, autoscaler will create it with the default params, given name and namespace. It is needed for properly integrating this autoscaler with kube-dns addon on kubernetes.

README is updated and examples are added.

@bowei @thockin @bprashanth 
