### PR TITLE
Adds Travis CI to autoscaler repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+# trusty required for docker
+# https://github.com/travis-ci/travis-ci/issues/5448
+dist: trusty
+
+services:
+  - docker
+
+script:
+  - make test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Horizontal cluster-proportional-autoscaler container
 
+[![Build Status](https://travis-ci.org/kubernetes-incubator/cluster-proportional-autoscaler.png)](https://travis-ci.org/kubernetes-incubator/cluster-proportional-autoscaler)
+
 This container image watches over the number of schedulable nodes and cores of the cluster and resizes
 the number of replicas for the required resource. This functionality may be desirable for applications
 that need to be autoscaled with the size of the cluster, such as DNS and other services that scale


### PR DESCRIPTION
Have enabled travis-ci for this repo on travis-ci.org.

Did not specify language as we are using docker to build.

@bowei 