### PR TITLE
Changes PerReplica params to floats and adds unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The equation of linear control mode as below:
 replicas = max( ceil( cores * 1/coresPerReplica ) , ceil( nodes * 1/nodesPerReplica ) )
 ```
 
+Notice that both `coresPerReplica` and `nodesPerReplica` are float.
+
 For instance, given a cluster has 4 nodes and 13 cores. With above parameters, each replica could take care of 1 node.
 So we need `4 / 1 = 4` replicas to take care of all 4 nodes. And each replica could take care of 2 cores. We need `ceil(13 / 2) = 7`
 replicas to take care of all 13 cores. Controller will choose the greater one, which is `7` here, as the result.
@@ -112,7 +114,8 @@ The replicas derived from "cores_to_replicas_map" would be `3` (because `64` < `
 The replicas derived from "nodes_to_replicas_map" would be `2` (because `100` > `2`).   
 And we would choose the larger one `3`.
 
-Either one of the `coresToReplicas` or `nodesToReplicas` could be omitted.
+Either one of the `coresToReplicas` or `nodesToReplicas` could be omitted. All elements in them should
+be int.
 
 The lowest number of replicas is set to 1.
 

--- a/pkg/autoscaler/controller/linearcontroller/linear_controller.go
+++ b/pkg/autoscaler/controller/linearcontroller/linear_controller.go
@@ -43,10 +43,10 @@ func NewLinearController() controller.Controller {
 }
 
 type linearParams struct {
-	CoresPerReplica int `json:"coresPerReplica"`
-	NodesPerReplica int `json:"nodesPerReplica"`
-	Min             int `json:"min"`
-	Max             int `json:"max"`
+	CoresPerReplica float64 `json:"coresPerReplica"`
+	NodesPerReplica float64 `json:"nodesPerReplica"`
+	Min             int     `json:"min"`
+	Max             int     `json:"max"`
 }
 
 func (c *LinearController) SyncConfig(configMap *k8sclient.ConfigMap) error {
@@ -110,11 +110,11 @@ func (c *LinearController) getExpectedReplicasFromParams(schedulableNodes, sched
 	return replicasFromNode
 }
 
-func (c *LinearController) getExpectedReplicasFromParam(schedulableResources, resourcesPerReplica int) int {
+func (c *LinearController) getExpectedReplicasFromParam(schedulableResources int, resourcesPerReplica float64) int {
 	if resourcesPerReplica == 0 {
 		return 1
 	}
-	res := math.Ceil(float64(schedulableResources) / float64(resourcesPerReplica))
+	res := math.Ceil(float64(schedulableResources) / resourcesPerReplica)
 	if c.params.Max != 0 {
 		res = math.Min(float64(c.params.Max), res)
 	}

--- a/pkg/autoscaler/controller/linearcontroller/linear_controller_test.go
+++ b/pkg/autoscaler/controller/linearcontroller/linear_controller_test.go
@@ -144,7 +144,7 @@ func TestScaleFromMultipleParams(t *testing.T) {
 	testController := &LinearController{}
 	testController.params = &linearParams{
 		CoresPerReplica: 2,
-		NodesPerReplica: 2,
+		NodesPerReplica: 2.5,
 		Min:             2,
 		Max:             100,
 	}
@@ -162,11 +162,12 @@ func TestScaleFromMultipleParams(t *testing.T) {
 		{6, 4, 3},
 		{6, 5, 3},
 		{8, 5, 4},
-		{11, 14, 7},
-		{19, 21, 11},
+		{8, 15, 6},
+		{8, 16, 7},
+		{19, 21, 10},
 		{23, 20, 12},
-		{26, 24, 13},
-		{30, 30, 15},
+		{26, 38, 16},
+		{30, 49, 20},
 		{40, 20, 20},
 	}
 


### PR DESCRIPTION
Fixes #12.

Make PerReplica params floats to gain more precise control. One more unit test is added, I wonder should we combine the new `TestScaleFromSingleParamFloat()` with the old one?

@bowei 