### PR TITLE
Adds CHANGELOG for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+### Version 1.0.0 (Mon November 7 2016 Zihong Zheng <zihongz@google.com>)
+ - Releases autoscaler 1.0.0 with linear controller and default params support.

--- a/OWNERS
+++ b/OWNERS
@@ -4,5 +4,5 @@
 assignees:
   - thockin
   - erictune
-  - girishkalele
-
+  - zihongz
+  - bowei


### PR DESCRIPTION
Autoscaler 1.0.0 images for amd64, arm, arm64 and ppc64le are built and pushed this Monday.

Adds CHANGELOG for this release and corrects the OWNER file.

@bowei 