### PR TITLE
Support switching control mode on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ Usage of cluster-proportional-autoscaler:
 ```
       --alsologtostderr[=false]: log to standard error as well as files
       --configmap="": ConfigMap containing our scaling parameters.
-      --default-params="": Default parameters(JSON format) for auto-scaling. Will create/re-create a ConfigMap with this default params if not present.
+      --default-params=map[]: Default parameters(JSON format) for auto-scaling. Will create/re-create a ConfigMap with this default params if ConfigMap is not present.
       --log-backtrace-at=:0: when logging hits line file:N, emit a stack trace
       --log-dir="": If non-empty, write log files in this directory
       --logtostderr[=false]: log to standard error instead of files
-      --mode="linear": Control mode --- linear/ladder. Default is the linear mode.
       --namespace="": Namespace for all operations, fallback to the namespace of this autoscaler(through MY_POD_NAMESPACE env) if not specified.
       --poll-period-seconds=10: The time, in seconds, to check cluster status and perform autoscale.
       --stderrthreshold=2: logs at or above this threshold go to stderr
@@ -40,12 +39,12 @@ parameters table every poll interval to be up to date with the latest desired sc
 The desired number of replicas is computed by using the number of cores and nodes as input of the chosen controller.
 
 This may be later extended to more complex interpolation or exponential scaling schemes
-but it currently supports `linear` and `ladder` modes(default to `linear`).
+but it currently supports `linear` and `ladder` modes.
 
 # Control patterns and ConfigMap formats
 
-The ConfigMap provides the configuration parameters, allowing on-the-fly changes without rebuilding or
-restarting the scaler containers/pods.
+The ConfigMap provides the configuration parameters, allowing on-the-fly changes(including control mode) without
+rebuilding or restarting the scaler containers/pods.
 
 Currently the two supported ConfigMap key value is: `ladder` and `linear`, which corresponding to two supported control mode.
 

--- a/cmd/cluster-proportional-autoscaler/autoscaler.go
+++ b/cmd/cluster-proportional-autoscaler/autoscaler.go
@@ -42,14 +42,14 @@ func main() {
 
 	// Perform further validation of flags.
 	if err := config.ValidateFlags(); err != nil {
-		glog.Errorf("%v\n", err)
+		glog.Errorf("%v", err)
 		os.Exit(1)
 	}
 
-	glog.V(0).Infof("Scaling Namespace: %s, Target: %s, Mode: %v\n", config.Namespace, config.Target, config.Mode)
+	glog.V(0).Infof("Scaling Namespace: %s, Target: %s", config.Namespace, config.Target)
 	scaler, err := autoscaler.NewAutoScaler(config)
 	if err != nil {
-		glog.Errorf("%v\n", err)
+		glog.Errorf("%v", err)
 		os.Exit(1)
 	}
 	// Begin autoscaling.

--- a/cmd/cluster-proportional-autoscaler/options/options.go
+++ b/cmd/cluster-proportional-autoscaler/options/options.go
@@ -27,12 +27,11 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// AutoscalerServerConfig configures and runs an autoscaler server
+// AutoScalerConfig configures and runs an autoscaler server
 type AutoScalerConfig struct {
 	Target            string
 	ConfigMap         string
 	Namespace         string
-	Mode              string
 	DefaultParams     configMapData
 	PollPeriodSeconds int
 	PrintVer          bool
@@ -41,7 +40,6 @@ type AutoScalerConfig struct {
 func NewAutoScalerConfig() *AutoScalerConfig {
 	return &AutoScalerConfig{
 		Namespace:         os.Getenv("MY_POD_NAMESPACE"),
-		Mode:              "linear",
 		PollPeriodSeconds: 10,
 		PrintVer:          false,
 	}
@@ -55,15 +53,15 @@ func (c *AutoScalerConfig) ValidateFlags() error {
 	}
 	if c.ConfigMap == "" {
 		errorsFound = true
-		glog.Errorf("--configmap parameter cannot be empty\n")
+		glog.Errorf("--configmap parameter cannot be empty")
 	}
 	if c.Namespace == "" {
 		errorsFound = true
-		glog.Errorf("--namespace parameter not set and failed to fallback\n")
+		glog.Errorf("--namespace parameter not set and failed to fallback")
 	}
 	if c.PollPeriodSeconds < 1 {
 		errorsFound = true
-		glog.Errorf("--poll-period-seconds cannot be less than 1\n")
+		glog.Errorf("--poll-period-seconds cannot be less than 1")
 	}
 
 	// Log all sanity check errors before returning a single error string
@@ -75,13 +73,13 @@ func (c *AutoScalerConfig) ValidateFlags() error {
 
 func isTargetFormatValid(target string) bool {
 	if target == "" {
-		glog.Errorf("--target parameter cannot be empty\n")
+		glog.Errorf("--target parameter cannot be empty")
 		return false
 	}
 	if !strings.HasPrefix(target, "deployment/") &&
 		!strings.HasPrefix(target, "replicationcontroller/") &&
 		!strings.HasPrefix(target, "replicaset/") {
-		glog.Errorf("Target format error. Please use deployment/*, replicationcontroller/* or replicaset/* (not case sensitive).\n")
+		glog.Errorf("Target format error. Please use deployment/*, replicationcontroller/* or replicaset/* (not case sensitive).")
 		return false
 	}
 	return true
@@ -113,12 +111,11 @@ func (c *configMapData) Type() string {
 	return "configMapData"
 }
 
-// AddFlags adds flags for a specific ProxyServer to the specified FlagSet
+// AddFlags adds flags for a specific AutoScaler to the specified FlagSet
 func (c *AutoScalerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Target, "target", c.Target, "Target to scale. In format: deployment/*, replicationcontroller/* or replicaset/* (not case sensitive).")
 	fs.StringVar(&c.ConfigMap, "configmap", c.ConfigMap, "ConfigMap containing our scaling parameters.")
 	fs.StringVar(&c.Namespace, "namespace", c.Namespace, "Namespace for all operations, fallback to the namespace of this autoscaler(through MY_POD_NAMESPACE env) if not specified.")
-	fs.StringVar(&c.Mode, "mode", c.Mode, "Control mode(linear/ladder).")
 	fs.IntVar(&c.PollPeriodSeconds, "poll-period-seconds", c.PollPeriodSeconds, "The time, in seconds, to check cluster status and perform autoscale.")
 	fs.BoolVar(&c.PrintVer, "version", c.PrintVer, "Print the version and exit.")
 	fs.Var(&c.DefaultParams, "default-params", "Default parameters(JSON format) for auto-scaling. Will create/re-create a ConfigMap with this default params if ConfigMap is not present.")

--- a/pkg/autoscaler/controller/controller.go
+++ b/pkg/autoscaler/controller/controller.go
@@ -27,4 +27,6 @@ type Controller interface {
 	SyncConfig(*k8sclient.ConfigMap) error
 	// GetParamsVersion returns the latest parameters version from controller
 	GetParamsVersion() string
+	// GetControllerType returns the controller type
+	GetControllerType() string
 }

--- a/pkg/autoscaler/controller/laddercontroller/ladder_controller.go
+++ b/pkg/autoscaler/controller/laddercontroller/ladder_controller.go
@@ -64,7 +64,7 @@ type ladderParams struct {
 }
 
 func (c *LadderController) SyncConfig(configMap *k8sclient.ConfigMap) error {
-	glog.V(0).Infof("Detected ConfigMap version change (old: %s new: %s) - rebuilding lookup entries\n", c.version, configMap.Version)
+	glog.V(0).Infof("Detected ConfigMap version change (old: %s new: %s) - rebuilding lookup entries", c.version, configMap.Version)
 	glog.V(2).Infof("Params from apiserver: \n%v", configMap.Data[ControllerType])
 	params, err := parseParams([]byte(configMap.Data[ControllerType]))
 	if err != nil {
@@ -138,4 +138,8 @@ func getExpectedReplicasFromEntries(schedulableResources int, entries []paramEnt
 		pos = pos - 1
 	}
 	return entries[pos][1]
+}
+
+func (c *LadderController) GetControllerType() string {
+	return ControllerType
 }

--- a/pkg/autoscaler/controller/linearcontroller/linear_controller.go
+++ b/pkg/autoscaler/controller/linearcontroller/linear_controller.go
@@ -50,7 +50,7 @@ type linearParams struct {
 }
 
 func (c *LinearController) SyncConfig(configMap *k8sclient.ConfigMap) error {
-	glog.V(0).Infof("ConfigMap version change (old: %s new: %s) - rebuilding params\n", c.version, configMap.Version)
+	glog.V(0).Infof("ConfigMap version change (old: %s new: %s) - rebuilding params", c.version, configMap.Version)
 	glog.V(2).Infof("Params from apiserver: \n%v", configMap.Data[ControllerType])
 	params, err := parseParams([]byte(configMap.Data[ControllerType]))
 	if err != nil {
@@ -119,4 +119,8 @@ func (c *LinearController) getExpectedReplicasFromParam(schedulableResources int
 		res = math.Min(float64(c.params.Max), res)
 	}
 	return int(math.Max(float64(c.params.Min), res))
+}
+
+func (c *LinearController) GetControllerType() string {
+	return ControllerType
 }

--- a/pkg/autoscaler/controller/plugin/plugin.go
+++ b/pkg/autoscaler/controller/plugin/plugin.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/controller"
+	"github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/controller/laddercontroller"
+	"github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/controller/linearcontroller"
+	"github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/k8sclient"
+
+	"github.com/golang/glog"
+)
+
+// EnsureController ensures controller type and scaling params
+func EnsureController(cont controller.Controller, configMap *k8sclient.ConfigMap) (controller.Controller, error) {
+	// Expect only one entry, which uses the name of control mode as the key
+	if len(configMap.Data) != 1 {
+		return nil, fmt.Errorf("invalid configMap format, expected only one entry, got: %v", configMap.Data)
+	}
+	for mode := range configMap.Data {
+		// No need to reset controller if control pattern doesn't change
+		if cont != nil && mode == cont.GetControllerType() {
+			break
+		}
+		switch mode {
+		case laddercontroller.ControllerType:
+			cont = laddercontroller.NewLadderController()
+		case linearcontroller.ControllerType:
+			cont = linearcontroller.NewLinearController()
+		default:
+			return nil, fmt.Errorf("not a supported control mode: %v", mode)
+		}
+		glog.V(1).Infof("Set control mode to %v", mode)
+	}
+
+	// Sync config with controller
+	if err := cont.SyncConfig(configMap); err != nil {
+		return nil, fmt.Errorf("Error syncing configMap with controller: %v", err)
+	}
+	return cont, nil
+}

--- a/pkg/autoscaler/controller/plugin/plugin_test.go
+++ b/pkg/autoscaler/controller/plugin/plugin_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/k8sclient"
+)
+
+func TestEnsureController(t *testing.T) {
+	testCases := []struct {
+		configMap *k8sclient.ConfigMap
+		expError  bool
+	}{
+		{
+			&k8sclient.ConfigMap{
+				Data: map[string]string{
+					"invalidmode": "",
+				},
+			},
+			true,
+		},
+		{
+			&k8sclient.ConfigMap{
+				Data: map[string]string{
+					"toomanyentries1": "",
+					"toomanyentries2": "",
+				},
+			},
+			true,
+		},
+		{
+			&k8sclient.ConfigMap{
+				Data: map[string]string{
+					"linear": "{\"nodesPerReplica\":1}",
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := EnsureController(nil, tc.configMap)
+		if err != nil && !tc.expError {
+			t.Errorf("Expect no error, got error for configMap %v, error msg: %v", tc.configMap, err)
+			continue
+		} else if err == nil && tc.expError {
+			t.Errorf("Expect error, got no error for configMap %v, error msg: %v", tc.configMap, err)
+			continue
+		}
+	}
+}

--- a/pkg/autoscaler/k8sclient/k8sclient.go
+++ b/pkg/autoscaler/k8sclient/k8sclient.go
@@ -117,7 +117,7 @@ func (k *k8sClient) CreateConfigMap(namespace, configmap string, params map[stri
 	if err != nil {
 		return nil, err
 	}
-	glog.V(0).Infof("Created ConfigMap %v in namespace %v\n", configmap, namespace)
+	glog.V(0).Infof("Created ConfigMap %v in namespace %v", configmap, namespace)
 	return &ConfigMap{cm.Data, cm.ObjectMeta.ResourceVersion}, nil
 }
 
@@ -130,7 +130,7 @@ func (k *k8sClient) UpdateConfigMap(namespace, configmap string, params map[stri
 	if err != nil {
 		return nil, err
 	}
-	glog.V(0).Infof("Updated ConfigMap %v in namespace %v\n", configmap, namespace)
+	glog.V(0).Infof("Updated ConfigMap %v in namespace %v", configmap, namespace)
 	return &ConfigMap{cm.Data, cm.ObjectMeta.ResourceVersion}, nil
 }
 
@@ -177,8 +177,8 @@ func (k *k8sClient) UpdateReplicas(expReplicas int32) (prevRelicas int32, err er
 	}
 	prevRelicas = scale.Spec.Replicas
 	if expReplicas != prevRelicas {
-		glog.V(0).Infof("Cluster status: SchedulableNodes[%v], SchedulableCores[%v]\n", k.clusterStatus.SchedulableNodes, k.clusterStatus.SchedulableCores)
-		glog.V(0).Infof("Replicas are not as expected : updating replicas from %d to %d\n", prevRelicas, expReplicas)
+		glog.V(0).Infof("Cluster status: SchedulableNodes[%v], SchedulableCores[%v]", k.clusterStatus.SchedulableNodes, k.clusterStatus.SchedulableCores)
+		glog.V(0).Infof("Replicas are not as expected : updating replicas from %d to %d", prevRelicas, expReplicas)
 		scale.Spec.Replicas = expReplicas
 		_, err = k.clientset.Extensions().Scales(k.target.namespace).Update(k.target.kind, scale)
 		if err != nil {


### PR DESCRIPTION
Fixed #6.

Parses out the specified control mode from configMap in loop and ensures corresponding controller on changes.

Adds unit test cases for switching control pattern and linear controller in mocking server test.

@bowei