### PR TITLE
Adds RBAC related config files to examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.org/kubernetes-incubator/cluster-proportional-autoscaler.png)](https://travis-ci.org/kubernetes-incubator/cluster-proportional-autoscaler)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-incubator/cluster-proportional-autoscaler)](https://goreportcard.com/report/github.com/kubernetes-incubator/cluster-proportional-autoscaler)
 
+## Overview
+
 This container image watches over the number of schedulable nodes and cores of the cluster and resizes
 the number of replicas for the required resource. This functionality may be desirable for applications
 that need to be autoscaled with the size of the cluster, such as DNS and other services that scale
@@ -26,7 +28,11 @@ Usage of cluster-proportional-autoscaler:
       --vmodule=: comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-# Implementation Details
+## Examples
+
+Please try out the examples in [the examples folder](examples/README.md).
+
+## Implementation Details
 
 The code in this module is a Kubernetes Golang API client that, using the default service account credentials
 available to Golang clients running inside pods, it connects to the API server and polls for the number of nodes
@@ -35,21 +41,21 @@ and cores in the cluster.
 The scaling parameters and data points are provided via a ConfigMap to the autoscaler and it refreshes its
 parameters table every poll interval to be up to date with the latest desired scaling parameters.
 
-## Calculation of number of replicas
+### Calculation of number of replicas
 
 The desired number of replicas is computed by using the number of cores and nodes as input of the chosen controller.
 
 This may be later extended to more complex interpolation or exponential scaling schemes
 but it currently supports `linear` and `ladder` modes.
 
-# Control patterns and ConfigMap formats
+## Control patterns and ConfigMap formats
 
 The ConfigMap provides the configuration parameters, allowing on-the-fly changes(including control mode) without
 rebuilding or restarting the scaler containers/pods.
 
 Currently the two supported ConfigMap key value is: `ladder` and `linear`, which corresponding to two supported control mode.
 
-## Linear Mode
+### Linear Mode
 
 Parameters in ConfigMap must be JSON and use `linear` as key. The sub-keys as below indicates:
 
@@ -80,7 +86,7 @@ If not set, `min` would be default to 1.
 
 The lowest number of replicas is set to 1.
 
-## Ladder Mode
+### Ladder Mode
 
 Parameters in ConfigMap must be JSON and use `ladder` as key. The sub-keys as below indicates:
 
@@ -119,19 +125,7 @@ be int.
 
 The lowest number of replicas is set to 1.
 
-## Example deployment files
-
-There are several example yaml files in the example folder, each of them will deploy an autoscaler pod watch and resizes the Deployment replicas of the nginx server.
-They are using different control modes. The autoscaler accepts default parameters passed by `--default-params` flag. Default ConfigMap will be created/re-created if default params present. Also see the example yaml files for example.
-
-Use below command to create / delete one of the example:
-```
-kubectl create -f linear.yaml
-...
-kubectl delete -f linear.yaml
-```
-
-# Comparisons to the Horizontal Pod Autoscaler feature
+## Comparisons to the Horizontal Pod Autoscaler feature
 
 The [Horizontal Pod Autoscaler](http://kubernetes.io/docs/user-guide/horizontal-pod-autoscaling/) is a top-level Kubernetes API resource. It is a closed feedback loop autoscaler which monitors CPU utilization of the pods and scales the number of replicas automatically. It requires the CPU resources to be defined for all containers in the target pods and also requires heapster to be running to provide CPU utilization metrics.
 

--- a/examples/RBAC/RBAC-configs.yaml
+++ b/examples/RBAC/RBAC-configs.yaml
@@ -1,0 +1,50 @@
+# Copyright 2016 The Kubernetes Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cluster-proportional-autoscaler
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: cluster-proportional-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: cluster-proportional-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-proportional-autoscaler
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-proportional-autoscaler
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,29 @@
+# Example files
+
+There are several example yaml files in this folder, each of them will create
+an autoscaler Deployment watches and resizes the replicas of the nginx server.
+They are using different control modes.
+
+Use below commands to create / delete one of the example:
+```
+kubectl create -f linear.yaml
+...
+kubectl delete -f linear.yaml
+```
+P.S. You need to delete the created configMap explicitly when using
+*-defaultparams.yaml.
+
+# RBAC configurations
+
+RBAC authentication has been enabled by default in Kubernetes 1.6+. You will need
+to create the following RBAC resources to give the controller the permissions to
+function correctly.
+
+Use below commands to create / delete the RBAC resources:
+```
+kubectl create -f RBAC-configs.yaml
+...
+kubectl delete -f RBAC-configs.yaml
+```
+
+RBAC documentation: http://kubernetes.io/docs/admin/authorization/

--- a/examples/ladder-defaultparams.yaml
+++ b/examples/ladder-defaultparams.yaml
@@ -47,11 +47,6 @@ spec:
       containers:
         - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
           name: autoscaler
-          env:
-            - name: MY_POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           command:
             - /cluster-proportional-autoscaler
             - --namespace=default
@@ -61,3 +56,5 @@ spec:
             - --default-params={"ladder":{"coresToReplicas":[[1, 1],[2, 2],[3, 4],[512, 5]],"nodesToReplicas":[[ 1,1 ],[ 2,2 ]]}}
             - --logtostderr=true
             - --v=2
+      # Uncomment below line if you are using RBAC configs under the RBAC folder.
+      # serviceAccountName: cluster-proportional-autoscaler

--- a/examples/ladder.yaml
+++ b/examples/ladder.yaml
@@ -79,11 +79,6 @@ spec:
       containers:
         - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
           name: autoscaler
-          env:
-            - name: MY_POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           command:
             - /cluster-proportional-autoscaler
             - --namespace=default
@@ -92,3 +87,5 @@ spec:
             - --target=deployment/nginx-autoscale-example
             - --logtostderr=true
             - --v=2
+      # Uncomment below line if you are using RBAC configs under the RBAC folder.
+      # serviceAccountName: cluster-proportional-autoscaler

--- a/examples/linear-defaultparams.yaml
+++ b/examples/linear-defaultparams.yaml
@@ -47,11 +47,6 @@ spec:
       containers:
         - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
           name: autoscaler
-          env:
-            - name: MY_POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           command:
             - /cluster-proportional-autoscaler
             - --namespace=default
@@ -61,3 +56,5 @@ spec:
             - --default-params={"linear":{"coresPerReplica":2,"nodesPerReplica":1,"min":1}}
             - --logtostderr=true
             - --v=2
+      # Uncomment below line if you are using RBAC configs under the RBAC folder.
+      # serviceAccountName: cluster-proportional-autoscaler

--- a/examples/linear.yaml
+++ b/examples/linear.yaml
@@ -60,11 +60,6 @@ spec:
       containers:
         - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
           name: autoscaler
-          env:
-            - name: MY_POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           command:
             - /cluster-proportional-autoscaler
             - --namespace=default
@@ -73,3 +68,5 @@ spec:
             - --target=deployment/nginx-autoscale-example
             - --logtostderr=true
             - --v=2
+      # Uncomment below line if you are using RBAC configs under the RBAC folder.
+      # serviceAccountName: cluster-proportional-autoscaler


### PR DESCRIPTION
Fixes #20.

The RBAC configs are set up following the instructions on http://kubernetes.io/docs/admin/authorization/.

@bowei 