### PR TITLE
Release cluster-proportional-autoscaler 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
+### Version 1.1.0 (Wed February 22 2017 Zihong Zheng <zihongz@google.com>)
+ - Adds 'preventSinglePointFailure' option to linear controller and supports
+   switching control mode on-the-fly.
+
 ### Version 1.0.0 (Mon November 7 2016 Zihong Zheng <zihongz@google.com>)
  - Releases autoscaler 1.0.0 with linear controller and default params support.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ARCH ?= amd64
 VERSION := $(shell git describe --always --dirty)
 #
 # This version-strategy uses a manual value to set the version string
-# VERSION := 1.0.0
+# VERSION := 1.1.0
 
 ###
 ### These variables should not need tweaking.

--- a/examples/ladder-defaultparams.yaml
+++ b/examples/ladder-defaultparams.yaml
@@ -45,13 +45,12 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler
             - --namespace=default
             - --configmap=nginx-autoscaler
-            - --mode=ladder
             - --target=deployment/nginx-autoscale-example
             - --default-params={"ladder":{"coresToReplicas":[[1, 1],[2, 2],[3, 4],[512, 5]],"nodesToReplicas":[[ 1,1 ],[ 2,2 ]]}}
             - --logtostderr=true

--- a/examples/ladder.yaml
+++ b/examples/ladder.yaml
@@ -77,13 +77,12 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler
             - --namespace=default
             - --configmap=nginx-autoscaler
-            - --mode=ladder
             - --target=deployment/nginx-autoscale-example
             - --logtostderr=true
             - --v=2

--- a/examples/linear-defaultparams.yaml
+++ b/examples/linear-defaultparams.yaml
@@ -45,15 +45,14 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler
             - --namespace=default
             - --configmap=nginx-autoscaler
-            - --mode=linear
             - --target=deployment/nginx-autoscale-example
-            - --default-params={"linear":{"coresPerReplica":2,"nodesPerReplica":1,"min":1}}
+            - --default-params={"linear":{"coresPerReplica":2,"nodesPerReplica":1,"preventSinglePointFailure":true}}
             - --logtostderr=true
             - --v=2
       # Uncomment below line if you are using RBAC configs under the RBAC folder.

--- a/examples/linear.yaml
+++ b/examples/linear.yaml
@@ -22,7 +22,7 @@ data:
     { 
       "coresPerReplica": 2,
       "nodesPerReplica": 1,
-      "min": 1
+      "preventSinglePointFailure": true
     }
 ---
 apiVersion: extensions/v1beta1
@@ -58,13 +58,12 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler
             - --namespace=default
             - --configmap=nginx-autoscaler
-            - --mode=linear
             - --target=deployment/nginx-autoscale-example
             - --logtostderr=true
             - --v=2


### PR DESCRIPTION
k8s v1.6 code freeze is one week away. I'd like to cut a new release for cluster-proportional-autoscaler to support:
- Switching control mode on-the-fly.
- `PreventSinglePointFailure` option in linear mode.

Will send PR to upstream to bump up 'dns-horizontal-autoscaler' and push the 1.1.0 tag after merged.

@bowei 

---

Below images have been pushed:
- gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0
- gcr.io/google_containers/cluster-proportional-autoscaler-arm:1.1.0
- gcr.io/google_containers/cluster-proportional-autoscaler-arm64:1.1.0
- gcr.io/google_containers/cluster-proportional-autoscaler-ppc64le:1.1.0