### PR TITLE
Release cluster-proportional-autoscaler 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 1.1.1 (Thu February 23 2017 Zihong Zheng <zihongz@google.com>)
+ - Use protobufs for communication with apiserver.
+
 ### Version 1.1.0 (Wed February 22 2017 Zihong Zheng <zihongz@google.com>)
  - Adds 'preventSinglePointFailure' option to linear controller and supports
    switching control mode on-the-fly.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ARCH ?= amd64
 VERSION := $(shell git describe --always --dirty)
 #
 # This version-strategy uses a manual value to set the version string
-# VERSION := 1.1.0
+# VERSION := 1.1.1
 
 ###
 ### These variables should not need tweaking.
@@ -114,7 +114,7 @@ container-name:
 
 push: .push-$(DOTFILE_IMAGE) push-name
 .push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
-	@gcloud docker push $(IMAGE):$(VERSION)
+	@gcloud docker -- push $(IMAGE):$(VERSION)
 	@docker images -q $(IMAGE):$(VERSION) > $@
 
 push-name:

--- a/examples/RBAC/RBAC-configs.yaml
+++ b/examples/RBAC/RBAC-configs.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: default
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-proportional-autoscaler
 rules:
@@ -37,7 +37,7 @@ rules:
     verbs: ["get", "create"]
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-proportional-autoscaler
 subjects:

--- a/examples/ladder-defaultparams.yaml
+++ b/examples/ladder-defaultparams.yaml
@@ -45,7 +45,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/examples/ladder.yaml
+++ b/examples/ladder.yaml
@@ -77,7 +77,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/examples/linear-defaultparams.yaml
+++ b/examples/linear-defaultparams.yaml
@@ -45,7 +45,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/examples/linear.yaml
+++ b/examples/linear.yaml
@@ -58,7 +58,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler


### PR DESCRIPTION
Sorry for releasing twice in two days. This patch release picks up #25 includes below feature that would be super useful for k8s 1.6:
- Use protobufs for communication with apiserver.

@bowei 

---

Below images have been pushed:
- gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
- gcr.io/google_containers/cluster-proportional-autoscaler-arm:1.1.1
- gcr.io/google_containers/cluster-proportional-autoscaler-arm64:1.1.1
- gcr.io/google_containers/cluster-proportional-autoscaler-ppc64le:1.1.1