### PR TITLE
Release cluster-proportional-autoscaler 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 1.1.2 (Thu June 1 2017 Zihong Zheng <zihongz@google.com>)
+ - Update client-go to 3.0 beta.
+
 ### Version 1.1.1 (Thu February 23 2017 Zihong Zheng <zihongz@google.com>)
  - Use protobufs for communication with apiserver.
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ARCH ?= amd64
 VERSION := $(shell git describe --always --dirty)
 #
 # This version-strategy uses a manual value to set the version string
-# VERSION := 1.1.1
+# VERSION := 1.1.2
 
 ###
 ### These variables should not need tweaking.

--- a/examples/RBAC/RBAC-configs.yaml
+++ b/examples/RBAC/RBAC-configs.yaml
@@ -15,13 +15,13 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: cluster-proportional-autoscaler
+  name: cluster-proportional-autoscaler-example
   namespace: default
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: cluster-proportional-autoscaler
+  name: cluster-proportional-autoscaler-example
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -39,12 +39,12 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: cluster-proportional-autoscaler
+  name: cluster-proportional-autoscaler-example
 subjects:
   - kind: ServiceAccount
-    name: cluster-proportional-autoscaler
+    name: cluster-proportional-autoscaler-example
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: cluster-proportional-autoscaler
+  name: cluster-proportional-autoscaler-example
   apiGroup: rbac.authorization.k8s.io

--- a/examples/ladder-defaultparams.yaml
+++ b/examples/ladder-defaultparams.yaml
@@ -45,7 +45,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler
@@ -56,4 +56,4 @@ spec:
             - --logtostderr=true
             - --v=2
       # Uncomment below line if you are using RBAC configs under the RBAC folder.
-      # serviceAccountName: cluster-proportional-autoscaler
+      # serviceAccountName: cluster-proportional-autoscaler-example

--- a/examples/ladder.yaml
+++ b/examples/ladder.yaml
@@ -77,7 +77,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler
@@ -87,4 +87,4 @@ spec:
             - --logtostderr=true
             - --v=2
       # Uncomment below line if you are using RBAC configs under the RBAC folder.
-      # serviceAccountName: cluster-proportional-autoscaler
+      # serviceAccountName: cluster-proportional-autoscaler-example

--- a/examples/linear-defaultparams.yaml
+++ b/examples/linear-defaultparams.yaml
@@ -45,7 +45,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler
@@ -56,4 +56,4 @@ spec:
             - --logtostderr=true
             - --v=2
       # Uncomment below line if you are using RBAC configs under the RBAC folder.
-      # serviceAccountName: cluster-proportional-autoscaler
+      # serviceAccountName: cluster-proportional-autoscaler-example

--- a/examples/linear.yaml
+++ b/examples/linear.yaml
@@ -58,7 +58,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler
@@ -68,4 +68,4 @@ spec:
             - --logtostderr=true
             - --v=2
       # Uncomment below line if you are using RBAC configs under the RBAC folder.
-      # serviceAccountName: cluster-proportional-autoscaler
+      # serviceAccountName: cluster-proportional-autoscaler-example


### PR DESCRIPTION
Release note:
- Update client-go to 3.0 beta.

Below images have been pushed:

- gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
- gcr.io/google_containers/cluster-proportional-autoscaler-arm:1.1.2
- gcr.io/google_containers/cluster-proportional-autoscaler-arm64:1.1.2
- gcr.io/google_containers/cluster-proportional-autoscaler-ppc64le:1.1.2

@bowei 