### PR TITLE
Release cluster-proportional-autoscaler 1.1.2-r2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 1.1.2-r2 (Mon June 12 2017 Zihong Zheng <zihongz@google.com>)
+ - Update base image and rebuild.
+
 ### Version 1.1.2 (Thu June 1 2017 Zihong Zheng <zihongz@google.com>)
  - Update client-go to 3.0 beta.
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ARCH ?= amd64
 VERSION := $(shell git describe --always --dirty)
 #
 # This version-strategy uses a manual value to set the version string
-# VERSION := 1.1.2
+# VERSION := 1.1.2-r2
 
 ###
 ### These variables should not need tweaking.
@@ -106,7 +106,7 @@ container: .container-$(DOTFILE_IMAGE) container-name
 	    -e 's|ARG_ARCH|$(ARCH)|g' \
 	    -e 's|ARG_FROM|$(BASEIMAGE)|g' \
 	    Dockerfile.in > .dockerfile-$(ARCH)
-	@docker build -t $(IMAGE):$(VERSION) -f .dockerfile-$(ARCH) .
+	@docker build --pull -t $(IMAGE):$(VERSION) -f .dockerfile-$(ARCH) .
 	@docker images -q $(IMAGE):$(VERSION) > $@
 
 container-name:


### PR DESCRIPTION
Add `--pull` flag to docker build and rebuild 1.1.2 images.

Below images have been pushed:
- gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2-r2
- gcr.io/google_containers/cluster-proportional-autoscaler-arm:1.1.2-r2
- gcr.io/google_containers/cluster-proportional-autoscaler-arm64:1.1.2-r2
- gcr.io/google_containers/cluster-proportional-autoscaler-ppc64le:1.1.2-r2

@ixdy
cc @bowei 

