### PR TITLE
Rename OWNERS assignees: to approvers:

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,7 @@
 # See the OWNERS file documentation:
 #  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
 
-assignees:
+approvers:
   - thockin
   - erictune
   - zihongz


### PR DESCRIPTION
They are effectively the same, assignees is deprecated

ref: kubernetes/test-infra#3851