### PR TITLE
Change container registry to staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BIN := cluster-proportional-autoscaler
 PKG := github.com/kubernetes-incubator/cluster-proportional-autoscaler
 
 # Where to push the docker image.
-REGISTRY ?= gcr.io/google_containers
+REGISTRY ?= staging-k8s.gcr.io
 
 # Which architecture to build - see $(ALL_ARCH) for options.
 ARCH ?= amd64


### PR DESCRIPTION
We should stop pushing image directly to `gcr.io/google-containers` and follow the new image push procedure (registry promoter).
cc @prameshj