### PR TITLE
update rbac to allow cluster-proportional-autoscaler watch nodes

### DIFF
--- a/examples/RBAC/RBAC-configs.yaml
+++ b/examples/RBAC/RBAC-configs.yaml
@@ -25,7 +25,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
     verbs: ["get", "update"]


### PR DESCRIPTION
The latest 1.2.0 version needs to watch nodes resource but related rbac rule is missing inside the example.