### PR TITLE
Add support for scaling via apps/v1 and v1 APIs

### DIFF
--- a/examples/RBAC/RBAC-configs.yaml
+++ b/examples/RBAC/RBAC-configs.yaml
@@ -29,7 +29,7 @@ rules:
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
     verbs: ["get", "update"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["extensions","apps"]
     resources: ["deployments/scale", "replicasets/scale"]
     verbs: ["get", "update"]
   - apiGroups: [""]


### PR DESCRIPTION
Attempts to scale using apps/v1 and v1 APIs first.

Falls back to existing behavior on permissions errors (in case the image is updated without updating the associated policy)

needed for https://github.com/kubernetes/kubernetes/pull/70672

Tested with and without extensions/v1beta1 enabled, ensured that scaling worked via the apps/v1 endpoints. Then tested with apps permissions removed and verified scaling fell back to the existing behavior