### PR TITLE
 Add support to filter nodes and its cpu by node labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Usage of cluster-proportional-autoscaler:
       --v=0: log level for V logs
       --version[=false]: Print the version and exit.
       --vmodule=: comma-separated list of pattern=N settings for file-filtered logging
+      --nodelabels=: NodeLabels for filtering search of nodes and its cpus by LabelSelectors. Input format is a comma separated list of keyN=valueN LabelSelectors. Usage example: --nodelabels=label1=value1,label2=value2.
 ```
 
 ## Examples
@@ -140,3 +141,7 @@ This horizontal cluster proportional autoscaler is a DIY container (because it i
 There is no requirement to run heapster and/or provide CPU resource limits as in HPAs.
 
 The ConfigMap provides the operator with the ability to tune the replica scaling explicitly.
+
+## Using NodeLabels
+
+Nodelabels is an optional param to count only nodes and its cpus where the nodelabels exits. This is useful when nodeselector is used on the target pods controller so its needed to take account only the nodes tagged with the nodeselector labels to calculate the total replicas to scale. When the param is ignored then the cluster proportional autoscaler counts all schedulable nodes and its cpus.

--- a/cmd/cluster-proportional-autoscaler/options/options.go
+++ b/cmd/cluster-proportional-autoscaler/options/options.go
@@ -35,6 +35,7 @@ type AutoScalerConfig struct {
 	DefaultParams     configMapData
 	PollPeriodSeconds int
 	PrintVer          bool
+	NodeLabels        string
 }
 
 // NewAutoScalerConfig returns a Autoscaler config
@@ -121,4 +122,5 @@ func (c *AutoScalerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&c.PollPeriodSeconds, "poll-period-seconds", c.PollPeriodSeconds, "The time, in seconds, to check cluster status and perform autoscale.")
 	fs.BoolVar(&c.PrintVer, "version", c.PrintVer, "Print the version and exit.")
 	fs.Var(&c.DefaultParams, "default-params", "Default parameters(JSON format) for auto-scaling. Will create/re-create a ConfigMap with this default params if ConfigMap is not present.")
+	fs.StringVar(&c.NodeLabels, "nodelabels", c.NodeLabels, "NodeLabels for filtering search of nodes and its cpus by LabelSelectors. Input format is a comma separated list of keyN=valueN LabelSelectors. Usage example: --nodelabels=label1=value1,label2=value2.")
 }

--- a/pkg/autoscaler/autoscaler_server.go
+++ b/pkg/autoscaler/autoscaler_server.go
@@ -44,7 +44,7 @@ type AutoScaler struct {
 
 // NewAutoScaler returns a new AutoScaler
 func NewAutoScaler(c *options.AutoScalerConfig) (*AutoScaler, error) {
-	newK8sClient, err := k8sclient.NewK8sClient(c.Namespace, c.Target)
+	newK8sClient, err := k8sclient.NewK8sClient(c.Namespace, c.Target, c.NodeLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/autoscaler/k8sclient/k8sclient.go
+++ b/pkg/autoscaler/k8sclient/k8sclient.go
@@ -62,7 +62,7 @@ type k8sClient struct {
 }
 
 // NewK8sClient gives a k8sClient with the given dependencies.
-func NewK8sClient(namespace, target string) (K8sClient, error) {
+func NewK8sClient(namespace, target string, nodelabels string) (K8sClient, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
@@ -80,12 +80,14 @@ func NewK8sClient(namespace, target string) (K8sClient, error) {
 	}
 
 	// Start propagating contents of the nodeStore.
+
+	opts := metav1.ListOptions{LabelSelector: nodelabels}
 	nodeListWatch := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return clientset.Core().Nodes().List(options)
+			return clientset.Core().Nodes().List(opts)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return clientset.Core().Nodes().Watch(options)
+			return clientset.Core().Nodes().Watch(opts)
 		},
 	}
 	nodeStore := cache.NewStore(cache.MetaNamespaceKeyFunc)


### PR DESCRIPTION
All nodes without `NoSchedulling` are taken by cluster-proportional-autoscaler to calculate SchedulableNodes and its SchedulableCores, including master nodes used as masters with taints without explicit `NoSchedulling` impacting the final result considering resources that may not necessarily be used.

Now an optional flag is added --nodelabels its takes a list of labels as key=value. 
Examples:
```
--nodelabels=instancetype=type1
```

```
--nodelabels=prod=true,storage=fast
```
This considers the use cases where you want to scale replicas that use nodeselector, where you need to calculate SchedulableNodes and SchedulableCores  using only the nodes where the tags exist.

if the flag is omitted then the cluster-proportional-autoscaler runs with previous default behavior.
