### PR TITLE
Update example template to use latest release

### DIFF
--- a/examples/ladder-defaultparams.yaml
+++ b/examples/ladder-defaultparams.yaml
@@ -45,7 +45,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:{LATEST_RELEASE}
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/examples/ladder.yaml
+++ b/examples/ladder.yaml
@@ -77,7 +77,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:{LATEST_RELEASE}
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/examples/linear-defaultparams.yaml
+++ b/examples/linear-defaultparams.yaml
@@ -45,7 +45,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:{LATEST_RELEASE}
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/examples/linear.yaml
+++ b/examples/linear.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: default
 data:
   linear: |-
-    { 
+    {
       "coresPerReplica": 2,
       "nodesPerReplica": 1,
       "preventSinglePointFailure": true
@@ -58,7 +58,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:{LATEST_RELEASE}
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler


### PR DESCRIPTION
Replacing the hardcoded version tag so we won't need to update it every time we bump the version.