### PR TITLE
add virtual-kubelet filter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.push-*
 /.container-*
 /.dockerfile-*
+.idea

--- a/pkg/autoscaler/k8sclient/k8sclient_test.go
+++ b/pkg/autoscaler/k8sclient/k8sclient_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package k8sclient
 
 import (
-	"testing"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
+	"testing"
 )
 
 func TestGetScaleTarget(t *testing.T) {

--- a/pkg/autoscaler/k8sclient/k8sclient_test.go
+++ b/pkg/autoscaler/k8sclient/k8sclient_test.go
@@ -18,6 +18,7 @@ package k8sclient
 
 import (
 	"testing"
+	apiv1 "k8s.io/client-go/pkg/api/v1"
 )
 
 func TestGetScaleTarget(t *testing.T) {
@@ -66,4 +67,39 @@ func TestGetScaleTarget(t *testing.T) {
 			t.Errorf("Expect kind: %v, name: %v\ngot kind: %v, name: %v", tc.expKind, tc.expName, res.kind, res.name)
 		}
 	}
+}
+
+func TestFilterSkippedNode(t *testing.T) {
+	testCases := []struct {
+		labels     map[string]string
+		expSkipped bool
+	}{
+		{
+			// empty labels
+			map[string]string{},
+			false,
+		},
+		{
+			// standard node
+			map[string]string{
+				"type": "node",
+			},
+			false,
+		},
+		{
+			// virtual node
+			map[string]string{
+				"type": "virtual-kubelet",
+			},
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		node := &apiv1.Node{}
+		node.Labels = tc.labels
+		if skipped := filterSkippedNode(node); skipped != tc.expSkipped {
+			t.Errorf("Expect skipped: %v not skipped: %v\n Labels are %v", tc.expSkipped, skipped, tc.labels)
+		}
+	}
+
 }


### PR DESCRIPTION
<a href="https://github.com/virtual-kubelet/virtual-kubelet" target="_blank">virtual-kubelet</a> is an open source Kubernetes kubelet implementation that masquerades as a kubelet for the purposes of connecting Kubernetes to other APIs. This allows the nodes to be backed by other services like ACI, AWS Fargate. 

virtual-kubelet has large amount of capacity which will mislead cluster-proportional-autoscaler calculate the wrong replicas. Here is the case.

nodes:
```
NAME                       STATUS   ROLES    AGE   VERSION
cn-beijing.192.168.1.161   Ready    master   13d   v1.12.6-aliyun.1
cn-beijing.192.168.1.162   Ready    <none>   13d   v1.12.6-aliyun.1
cn-beijing.192.168.1.163   Ready    <none>   10d   v1.12.6-aliyun.1
cn-beijing.192.168.2.65    Ready    master   13d   v1.12.6-aliyun.1
cn-beijing.192.168.2.66    Ready    <none>   13d   v1.12.6-aliyun.1
cn-beijing.192.168.3.166   Ready    master   13d   v1.12.6-aliyun.1
cn-beijing.192.168.3.167   Ready    <none>   13d   v1.12.6-aliyun.1
virtual-kubelet            Ready    agent    13d   v1.11.2
```
virtual-kubelet 
```
➜  cluster-proportional-autoscaler git:(feature/filter-virtual-kubelet) kubectl describe node virtual-kubelet
Name:               virtual-kubelet
Roles:              agent
Labels:             alpha.service-controller.kubernetes.io/exclude-balancer=true
                    beta.kubernetes.io/os=linux
                    kubernetes.io/hostname=virtual-kubelet
                    kubernetes.io/role=agent
                    type=virtual-kubelet
Annotations:        node.alpha.kubernetes.io/ttl: 0
CreationTimestamp:  Thu, 20 Jun 2019 17:41:58 +0800
Taints:             virtual-kubelet.io/provider=alibabacloud:NoSchedule
Unschedulable:      false
Conditions:
  Type                 Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
  ----                 ------  -----------------                 ------------------                ------                       -------
  Ready                True    Thu, 04 Jul 2019 11:42:48 +0800   Thu, 04 Jul 2019 11:42:48 +0800   KubeletReady                 kubelet is ready.
  OutOfDisk            False   Thu, 04 Jul 2019 11:42:48 +0800   Thu, 04 Jul 2019 11:42:48 +0800   KubeletHasSufficientDisk     kubelet has sufficient disk space available
  MemoryPressure       False   Thu, 04 Jul 2019 11:42:48 +0800   Thu, 04 Jul 2019 11:42:48 +0800   KubeletHasSufficientMemory   kubelet has sufficient memory available
  DiskPressure         False   Thu, 04 Jul 2019 11:42:48 +0800   Thu, 04 Jul 2019 11:42:48 +0800   KubeletHasNoDiskPressure     kubelet has no disk pressure
  NetworkUnavailable   False   Thu, 04 Jul 2019 11:42:48 +0800   Thu, 04 Jul 2019 11:42:48 +0800   RouteCreated                 RouteController created a route
Addresses:
  InternalIP:  172.20.2.134
Capacity:
 cpu:     1k
 memory:  4Ti
 pods:    1k
Allocatable:
 cpu:     1k
 memory:  4Ti
 pods:    1k
System Info:
 Machine ID:
 System UUID:
 Boot ID:
 Kernel Version:
 OS Image:
 Operating System:           Linux
 Architecture:               amd64
 Container Runtime Version:
 Kubelet Version:            v1.11.2
 Kube-Proxy Version:
PodCIDR:                     172.20.3.0/25
Non-terminated Pods:         (2 in total)
  Namespace                  Name                       CPU Requests  CPU Limits  Memory Requests  Memory Limits
  ---------                  ----                       ------------  ----------  ---------------  -------------
  ahas                       ahas-agent-9fmqb           50m (0%)      200m (0%)   200Mi (0%)       200Mi (0%)
  kube-system                kube-proxy-worker-t2xzh    0 (0%)        0 (0%)      0 (0%)           0 (0%)
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource  Requests    Limits
  --------  --------    ------
  cpu       50m (0%)    200m (0%)
  memory    200Mi (0%)  200Mi (0%)
Events:     <none>
```
e.g.  coredns autoscaler 
```
          - --namespace=kube-system
          - --configmap=dns-autoscaler
          - --target=Deployment/coredns
          - --default-params={"linear":{"coresPerReplica":16,"nodesPerReplica":2,"min":1,"max":100,"preventSinglePointFailure":true}}
          - --logtostderr=true
          - --v=2
```
The replicas will be 65, If not skipping virtual-kubelet else the replicas will be 4.
