### PR TITLE
Add required field  to example templates

### DIFF
--- a/examples/ladder-defaultparams.yaml
+++ b/examples/ladder-defaultparams.yaml
@@ -18,6 +18,9 @@ metadata:
   name: nginx-autoscale-example
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      run: nginx-autoscale-example
   replicas: 1
   template:
     metadata:
@@ -38,6 +41,9 @@ metadata:
   labels:
     app: autoscaler
 spec:
+  selector:
+    matchLabels:
+      app: autoscaler
   replicas: 1
   template:
     metadata:

--- a/examples/ladder.yaml
+++ b/examples/ladder.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: default
 data:
   ladder: |-
-    { 
+    {
       "coresToReplicas":
       [
         [ 1,1 ],
@@ -50,6 +50,9 @@ metadata:
   name: nginx-autoscale-example
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      run: nginx-autoscale-example
   replicas: 1
   template:
     metadata:
@@ -70,6 +73,9 @@ metadata:
   labels:
     app: autoscaler
 spec:
+  selector:
+    matchLabels:
+      app: autoscaler
   replicas: 1
   template:
     metadata:

--- a/examples/linear-defaultparams.yaml
+++ b/examples/linear-defaultparams.yaml
@@ -18,6 +18,9 @@ metadata:
   name: nginx-autoscale-example
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      run: nginx-autoscale-example
   replicas: 1
   template:
     metadata:
@@ -38,6 +41,9 @@ metadata:
   labels:
     app: autoscaler
 spec:
+ selector:
+    matchLabels:
+      app: autoscaler
   replicas: 1
   template:
     metadata:

--- a/examples/linear.yaml
+++ b/examples/linear.yaml
@@ -31,6 +31,9 @@ metadata:
   name: nginx-autoscale-example
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      run: nginx-autoscale-example
   replicas: 1
   template:
     metadata:
@@ -51,6 +54,9 @@ metadata:
   labels:
     app: autoscaler
 spec:
+  selector:
+    matchLabels:
+      app: autoscaler
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Ref https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/issues/61, example files are missing a required field hence not working.