### PR TITLE
Remove -ti in docker build to allow automation run the build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ build: bin/$(ARCH)/$(BIN)
 bin/$(ARCH)/$(BIN): build-dirs
 	@echo "building: $@"
 	@docker run                                                            \
-	    -ti                                                                \
 	    -u $$(id -u):$$(id -g)                                             \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
@@ -108,7 +107,6 @@ version:
 
 test: build-dirs
 	@docker run                                                            \
-	    -ti                                                                \
 	    -u $$(id -u):$$(id -g)                                             \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \


### PR DESCRIPTION
Remove -ti in docker build to allow automation run the build.