### PR TITLE
Allow ladder to support setting replicas to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,30 @@ The ladder controller gives out the desired replicas count by using a step funct
 The step ladder function uses the datapoint for core and node scaling from the ConfigMap.
 The lookup which yields the higher number of replicas will be used as the target scaling number.
 
-For instance, given a cluster comes with `100` nodes and `400` cores and it is using above ConfigMap.  
-The replicas derived from "cores_to_replicas_map" would be `3` (because `64` < `400` < `512`).  
-The replicas derived from "nodes_to_replicas_map" would be `2` (because `100` > `2`).   
+For instance, given a cluster comes with `100` nodes and `400` cores and it is using above ConfigMap.
+The replicas derived from "cores_to_replicas_map" would be `3` (because `64` < `400` < `512`).
+The replicas derived from "nodes_to_replicas_map" would be `2` (because `100` > `2`).
 And we would choose the larger one `3`.
 
 Either one of the `coresToReplicas` or `nodesToReplicas` could be omitted. All elements in them should
 be int.
 
-The lowest number of replicas is set to 0.
+Replicas can be set to 0 (unlike in linear mode).
+
+Scaling to 0 replicas could be used to enable optional features as a cluster grows. For example, this
+ladder would create a single replica once the cluster reaches six nodes.
+
+```
+data:
+  ladder: |-
+    {
+      "nodesToReplicas":
+      [
+        [ 0, 0 ],
+        [ 6, 1 ]
+      ]
+    }
+```
 
 ## Comparisons to the Horizontal Pod Autoscaler feature
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ And we would choose the larger one `3`.
 Either one of the `coresToReplicas` or `nodesToReplicas` could be omitted. All elements in them should
 be int.
 
-The lowest number of replicas is set to 1.
+The lowest number of replicas is set to 0.
 
 ## Comparisons to the Horizontal Pod Autoscaler feature
 

--- a/pkg/autoscaler/controller/laddercontroller/ladder_controller.go
+++ b/pkg/autoscaler/controller/laddercontroller/ladder_controller.go
@@ -92,7 +92,7 @@ func parseParams(data []byte) (*ladderParams, error) {
 		if len(e) != 2 {
 			return nil, fmt.Errorf("invalid element %v in cores_to_replicas_map", e)
 		}
-		if e[0] < 1 || e[1] < 1 {
+		if e[0] < 0 || e[1] < 0 {
 			return nil, fmt.Errorf("invalid negative values in entry %v in cores_to_replicas_map", e)
 		}
 	}
@@ -100,7 +100,7 @@ func parseParams(data []byte) (*ladderParams, error) {
 		if len(e) != 2 {
 			return nil, fmt.Errorf("invalid element %b in nodes_to_replicas_map", e)
 		}
-		if e[0] < 1 || e[1] < 1 {
+		if e[0] < 0 || e[1] < 0 {
 			return nil, fmt.Errorf("invalid negative values in entry %v in nodes_to_replicas_map", e)
 		}
 	}

--- a/pkg/autoscaler/controller/laddercontroller/ladder_controller_test.go
+++ b/pkg/autoscaler/controller/laddercontroller/ladder_controller_test.go
@@ -68,11 +68,6 @@ func TestControllerParser(t *testing.T) {
 			true,
 			&ladderParams{},
 		},
-		{ // Invalid value 0 in list
-			`{ "coresToReplicas" :  [[ 0, 1]] }`,
-			true,
-			&ladderParams{},
-		},
 		{ // Invalid negative in list
 			`{ "coresToReplicas" : [[:-200]] }`,
 			true,
@@ -82,7 +77,8 @@ func TestControllerParser(t *testing.T) {
 			`{
 				"coresToReplicas":
 				[
-					[1, 1],
+					[0, 0],
+					[1, 0],
 					[2, 2],
 					[3, 3],
 					[512, 5],
@@ -102,7 +98,8 @@ func TestControllerParser(t *testing.T) {
 			false,
 			&ladderParams{
 				CoresToReplicas: []paramEntry{
-					{1, 1},
+					{0, 0},
+					{1, 0},
 					{2, 2},
 					{3, 3},
 					{512, 5},
@@ -266,6 +263,38 @@ func TestControllerScaler(t *testing.T) {
 
 	for _, tc := range testCases {
 		if replicas := getExpectedReplicasFromEntries(tc.numResources, testEntries); tc.expReplicas != replicas {
+			t.Errorf("Scaler Lookup failed Expected %d, Got %d", tc.expReplicas, replicas)
+		}
+	}
+}
+
+func TestControllerScalerFromZero(t *testing.T) {
+	testEntries := []paramEntry{
+		{0, 0},
+		{3, 3},
+	}
+
+	testEntriesFromOne := []paramEntry{
+		{1, 0},
+		{3, 3},
+	}
+
+	testCases := []struct {
+		numResources int
+		expReplicas  int
+	}{
+		{0, 0},
+		{1, 0},
+		{2, 0},
+		{3, 3},
+		{4, 3},
+	}
+
+	for _, tc := range testCases {
+		if replicas := getExpectedReplicasFromEntries(tc.numResources, testEntries); tc.expReplicas != replicas {
+			t.Errorf("Scaler Lookup failed Expected %d, Got %d", tc.expReplicas, replicas)
+		}
+		if replicas := getExpectedReplicasFromEntries(tc.numResources, testEntriesFromOne); tc.expReplicas != replicas {
 			t.Errorf("Scaler Lookup failed Expected %d, Got %d", tc.expReplicas, replicas)
 		}
 	}


### PR DESCRIPTION
This removes the restriction that the lowest number of replicas that a
ladder can configure is 1. The linear mode already supports scaling
to zero with the config option preventSinglePointFailure. I believe
having an explicit safety option like this is not as necessary for
ladder as the zero case has to be explicitly enumerated.

This also removes the validation that the cores or nodes in the ladder
are 1 or greater, as 0 is a valid value for _schedulable_ nodes or cores
(especially when filtering by node labels). This is likely not strictly
necessary, but it makes the boundary condition somewhat more clear.