### PR TITLE
Add includeUnschedulableNodes option to linear controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ data:
       "min": 1,
       "max": 100,
       "preventSinglePointFailure": true
+      "includeUnschedulableNodes": true
     }
 ```
 
@@ -87,9 +88,13 @@ For instance, given a cluster has 4 nodes and 13 cores. With above parameters, e
 So we need `4 / 1 = 4` replicas to take care of all 4 nodes. And each replica could take care of 2 cores. We need `ceil(13 / 2) = 7`
 replicas to take care of all 13 cores. Controller will choose the greater one, which is `7` here, as the result.
 
-Either one of the `coresPerReplica` or `nodesPerReplica` could be omitted. All of  `min`, `max` and
-`preventSinglePointFailure` is optional. If not set, `min` would be default to `1`,
-`preventSinglePointFailure` will be default to `false`.
+When `includeUnschedulableNodes` is set to `true`, the replicas will scale based on the total number of nodes.
+Otherwise, the replicas will only scale based on the number of schedulable nodes (i.e., cordoned and draining nodes are
+excluded.) 
+
+Either one of the `coresPerReplica` or `nodesPerReplica` could be omitted. All of  `min`, `max`, 
+`preventSinglePointFailure` and `includeUnscheduleableNodes` are optional. If not set, `min` would be default to `1`,
+`preventSinglePointFailure` will be default to `false` and `includeUnschedulableNodes` will be default to `false`.
 
 Side notes:
 - Both `coresPerReplica` and `nodesPerReplica` are float.

--- a/examples/linear-defaultparams.yaml
+++ b/examples/linear-defaultparams.yaml
@@ -58,7 +58,7 @@ spec:
             - --namespace=default
             - --configmap=nginx-autoscaler
             - --target=deployment/nginx-autoscale-example
-            - --default-params={"linear":{"coresPerReplica":2,"nodesPerReplica":1,"preventSinglePointFailure":true}}
+            - --default-params={"linear":{"coresPerReplica":2,"nodesPerReplica":1,"preventSinglePointFailure":true,"includeUnschedulableNodes":true}}
             - --logtostderr=true
             - --v=2
       # Uncomment below line if you are using RBAC configs under the RBAC folder.

--- a/pkg/autoscaler/k8sclient/k8sclient.go
+++ b/pkg/autoscaler/k8sclient/k8sclient.go
@@ -227,7 +227,7 @@ func (k *k8sClient) UpdateReplicas(expReplicas int32) (prevRelicas int32, err er
 	}
 	prevRelicas = scale.Spec.Replicas
 	if expReplicas != prevRelicas {
-		glog.V(0).Infof("Cluster status: SchedulableNodes[%v], SchedulableCores[%v]", k.clusterStatus.SchedulableNodes, k.clusterStatus.SchedulableCores)
+		glog.V(0).Infof("Cluster status: SchedulableNodes[%v], TotalNodes[%v], SchedulableCores[%v], TotalCores[%v]", k.clusterStatus.SchedulableNodes, k.clusterStatus.TotalNodes, k.clusterStatus.SchedulableCores, k.clusterStatus.TotalCores)
 		glog.V(0).Infof("Replicas are not as expected : updating replicas from %d to %d", prevRelicas, expReplicas)
 		scale.Spec.Replicas = expReplicas
 		_, err = k.updateScaleExtensionsV1beta1(k.target, scale)


### PR DESCRIPTION
Resolves #77. Supports use cases where a large number of Nodes have to be marked unschedulable for a period of time.

For example, my team will often adds a small number of Nodes running a new version of the Node software image to a cluster, marks all existing Nodes (~80% of the cluster) as unschedule and migrates workloads to the new Nodes gracefully via the Eviction API and Cluster Autoscaler. This resolves an issue where CPA would scale services such as CoreDNS for the 20% of the cluster that is schedulable, even though the other 80% is still loading CoreDNS.

This change allows use to selectively use `includeUnschedulableNodes` when using CPA with services which are loaded by unschedulable nodes. It is off by default to maintain backwards compatibility.